### PR TITLE
Remove moz vendor prefix

### DIFF
--- a/_generic.box-sizing.scss
+++ b/_generic.box-sizing.scss
@@ -10,7 +10,6 @@
  */
 html {
     -webkit-box-sizing: border-box;
-       -moz-box-sizing: border-box;
             box-sizing: border-box;
 }
 
@@ -20,7 +19,6 @@ html {
     &:before,
     &:after {
         -webkit-box-sizing: inherit;
-           -moz-box-sizing: inherit;
                 box-sizing: inherit;
         }
 


### PR DESCRIPTION
It seems safe to remove the `moz` vendor prefix for `box-sizing` now:
http://caniuse.com/#feat=css3-boxsizing
